### PR TITLE
Added metrics to android checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,5 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,rider,dotnetcore,aspnetcore
+
+/dev-data

--- a/AppsTester.Checker.Android/Adb/AdbClientProvider.cs
+++ b/AppsTester.Checker.Android/Adb/AdbClientProvider.cs
@@ -86,7 +86,14 @@ namespace AppsTester.Checker.Android.Adb
 
         public void Dispose()
         {
-            _deviceMonitor.Dispose();
+            try
+            {
+                _deviceMonitor.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error while disposing device monitor");
+            }
         }
     }
 }

--- a/AppsTester.Checker.Android/Adb/AdbClientProvider.cs
+++ b/AppsTester.Checker.Android/Adb/AdbClientProvider.cs
@@ -23,13 +23,15 @@ namespace AppsTester.Checker.Android.Adb
         private readonly IMetricsService _metricsService;
         private readonly ILogger<AdbClientProvider> _logger;
 
-        public AdbClientProvider(IConfiguration configuration, IOptions<AdbOptions> adbOptions, IMetricsService metricsService, ILogger<AdbClientProvider> logger)
+        public AdbClientProvider(IOptions<AdbOptions> adbOptions, IMetricsService metricsService, ILogger<AdbClientProvider> logger)
         {
             var dnsEndPoint = new DnsEndPoint(adbOptions.Value.Host, port: 5037);
             _metricsService = metricsService;
             _logger = logger;
-
-            SetupAdbServer(Path.Combine(configuration.GetValue<string>("ANDROID_SDK_ROOT"), "platform-tools", RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "adb.exe" : "adb"));
+            if (!string.IsNullOrEmpty(adbOptions.Value.ExecutablePath))
+            {
+                SetupAdbServer(adbOptions.Value.ExecutablePath);
+            }
             SetupAdbClient(adbOptions.Value, dnsEndPoint);
             SetupDeviceMonitor(dnsEndPoint);
         }

--- a/AppsTester.Checker.Android/Adb/AdbClientProvider.cs
+++ b/AppsTester.Checker.Android/Adb/AdbClientProvider.cs
@@ -1,5 +1,9 @@
 using System;
+using System.IO;
 using System.Net;
+using System.Runtime.InteropServices;
+using AppsTester.Checker.Android.Metrics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpAdbClient;
@@ -15,15 +19,28 @@ namespace AppsTester.Checker.Android.Adb
     {
         private IAdbClient _adbClient;
         private IDeviceMonitor _deviceMonitor;
+
+        private readonly IMetricsService _metricsService;
         private readonly ILogger<AdbClientProvider> _logger;
 
-        public AdbClientProvider(IOptions<AdbOptions> adbOptions, ILogger<AdbClientProvider> logger)
+        public AdbClientProvider(IConfiguration configuration, IOptions<AdbOptions> adbOptions, IMetricsService metricsService, ILogger<AdbClientProvider> logger)
         {
             var dnsEndPoint = new DnsEndPoint(adbOptions.Value.Host, port: 5037);
+            _metricsService = metricsService;
             _logger = logger;
 
+            SetupAdbServer(Path.Combine(configuration.GetValue<string>("ANDROID_SDK_ROOT"), "platform-tools", RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "adb.exe" : "adb"));
             SetupAdbClient(adbOptions.Value, dnsEndPoint);
             SetupDeviceMonitor(dnsEndPoint);
+        }
+        private void SetupAdbServer(string adbPath)
+        {
+            if (!AdbServer.Instance.GetStatus().IsRunning)
+            {
+                _logger.LogInformation("ADB server {adbPath} is not running", adbPath);
+                var startResult = AdbServer.Instance.StartServer(adbPath, false);
+                _logger.LogInformation("ADB server start result {startResult}", startResult);
+            }
         }
         private void SetupAdbClient(AdbOptions configuration, EndPoint dnsEndPoint)
         {
@@ -43,11 +60,22 @@ namespace AppsTester.Checker.Android.Adb
         {
             _deviceMonitor = new DeviceMonitor(new AdbSocket(dnsEndPoint));
 
-            _deviceMonitor.DeviceConnected += (_, args) => _logger.LogInformation("Connected device with serial {Serial}", args.Device.Serial);
+            _deviceMonitor.DeviceConnected += (_, args) =>
+            {
+                _metricsService.CaptureDeviceConnected(args.Device.Serial);
+                _logger.LogInformation("Connected device with serial {Serial}", args.Device.Serial);
+            };
 
-            _deviceMonitor.DeviceDisconnected += (_, args) => _logger.LogInformation("Disconnected device with serial {Serial}", args.Device.Serial);
+            _deviceMonitor.DeviceDisconnected += (_, args) =>
+            {
+                _metricsService.CaptureDeviceDisconnected(args.Device.Serial);
+                _logger.LogInformation("Disconnected device with serial {Serial}", args.Device.Serial);
+            };
 
-            _deviceMonitor.DeviceChanged += (_, args) => _logger.LogInformation("Changed device with serial {Serial}", args.Device.Serial);
+            _deviceMonitor.DeviceChanged += (_, args) =>
+            {
+                _logger.LogInformation("Changed device with serial {Serial}", args.Device.Serial);
+            };
 
             _deviceMonitor.Start();
         }

--- a/AppsTester.Checker.Android/Adb/AdbOptions.cs
+++ b/AppsTester.Checker.Android/Adb/AdbOptions.cs
@@ -11,5 +11,6 @@ namespace AppsTester.Checker.Android.Adb
     {
         [Required]
         public string Host { get; set; }
+        public string ExecutablePath { get; set; }
     }
 }

--- a/AppsTester.Checker.Android/AppsTester.Checker.Android.csproj
+++ b/AppsTester.Checker.Android/AppsTester.Checker.Android.csproj
@@ -22,6 +22,8 @@
       <PackageReference Include="SharpZipLib" Version="1.3.1" />
       <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/AppsTester.Checker.Android/Metrics/MetricsService.cs
+++ b/AppsTester.Checker.Android/Metrics/MetricsService.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AppsTester.Checker.Android.Metrics
+{
+    public interface IMetricsService
+    {
+        public const string MeterName = "AppsTester.Checker.Android";
+        void CaptureDeviceConnected(string serialNumber);
+        void CaptureDeviceDisconnected(string serialNumber);
+    }
+    public class MetricsService : IMetricsService
+    {
+        private readonly Meter meter;
+
+        /// <summary>
+        /// Stores map of serial to label to prevent negative counter number on diconnect events by adb
+        /// </summary>
+        private readonly ConcurrentDictionary<string, KeyValuePair<string, object>> connectedDevices = new();
+        public MetricsService()
+        {
+            meter = new Meter(IMetricsService.MeterName);
+            meter.CreateObservableUpDownCounter("checker_devices_total", () => connectedDevices.Select(kvp => new Measurement<int>(1, kvp.Value)));
+        }
+        public void CaptureDeviceConnected(string serial)
+        {
+            connectedDevices.TryAdd(serial, new KeyValuePair<string, object>("serial", serial));
+        }
+
+        public void CaptureDeviceDisconnected(string serial)
+        {
+            connectedDevices.TryRemove(serial, out _);
+        }
+    }
+
+    public static class MetricsExtensions
+    {
+        public static void AddMetrics(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddSingleton<IMetricsService, MetricsService>();
+            var otlpExporterEndpoint = configuration.GetValue<string>("OtlpExporterEndpoint");
+            if (!string.IsNullOrEmpty(otlpExporterEndpoint))
+            {
+                var resouceBuilder = ResourceBuilder.CreateEmpty().AddService("AppsTester.Checker.Android");
+                services.AddOpenTelemetryMetrics(b =>
+                {
+                    b.SetResourceBuilder(resouceBuilder);
+                    b.AddMeter(IMetricsService.MeterName);
+                    b.AddOtlpExporter(options =>
+                    {
+                        options.Endpoint = new Uri(otlpExporterEndpoint);
+                    });
+                });
+            }
+        }
+    }
+}

--- a/AppsTester.Checker.Android/Program.cs
+++ b/AppsTester.Checker.Android/Program.cs
@@ -6,6 +6,7 @@ using AppsTester.Checker.Android.Apk;
 using AppsTester.Checker.Android.Devices;
 using AppsTester.Checker.Android.Gradle;
 using AppsTester.Checker.Android.Instrumentations;
+using AppsTester.Checker.Android.Metrics;
 using AppsTester.Shared.Files;
 using AppsTester.Shared.RabbitMq;
 using AppsTester.Shared.SubmissionChecker;
@@ -24,7 +25,7 @@ namespace AppsTester.Checker.Android
     {
         private static async Task Main(string[] args)
         {
-            await Host
+            var app = Host
                 .CreateDefaultBuilder(args)
                 .ConfigureServices((builder, services) =>
                 {
@@ -67,6 +68,8 @@ namespace AppsTester.Checker.Android
                             provider.GetService<IAdbDevicesProvider>(), distributedLockProvider);
                     });
 
+                    services.AddMetrics(builder.Configuration);
+
                     services.AddTemporaryFolders();
                     services.AddRabbitMq();
 
@@ -77,7 +80,13 @@ namespace AppsTester.Checker.Android
                     loggingBuilder.AddConsole();
                     loggingBuilder.AddSentry();
                 })
-                .RunConsoleAsync();
+                .UseConsoleLifetime()
+                .Build();
+
+            // initialize avd provider for devices listening
+            app.Services.GetRequiredService<IAdbClientProvider>();
+
+            await app.RunAsync();
         }
     }
 }

--- a/AppsTester.Checker.Android/appsettings.json
+++ b/AppsTester.Checker.Android/appsettings.json
@@ -9,5 +9,6 @@
   "Adb": {
     "Host": "localhost"
   },
-  "ANDROID_SDK_ROOT": "/home/ubuntu/android-sdk/"
+  "ANDROID_SDK_ROOT": "/home/ubuntu/android-sdk/",
+  "OtlpExporterEndpoint": "http://localhost:4317"
 }

--- a/AppsTester.Checker.Android/appsettings.json
+++ b/AppsTester.Checker.Android/appsettings.json
@@ -9,6 +9,5 @@
   "Adb": {
     "Host": "localhost"
   },
-  "ANDROID_SDK_ROOT": "/home/ubuntu/android-sdk/",
-  "OtlpExporterEndpoint": "http://localhost:4317"
+  "ANDROID_SDK_ROOT": "/home/ubuntu/android-sdk/"
 }

--- a/AppsTester.sln
+++ b/AppsTester.sln
@@ -12,7 +12,16 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B834C5F-3DE2-4E2A-901D-08683489CE21}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		docker-compose.yml = docker-compose.yml
+		otel-collector-config.yaml = otel-collector-config.yaml
+		prometheus.yaml = prometheus.yaml
 		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ci", "ci", "{87227351-3E72-4328-B02B-6D4BA5D50D50}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\update-android-checker.yml = .github\workflows\update-android-checker.yml
+		.github\workflows\update-controller.yml = .github\workflows\update-controller.yml
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ sequenceDiagram
     Controller ->> Moodle: Обновление результата решения
 
 ```
-
+## Конфигурация
+В рамках разработки параметры можно задавать через [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets)
+### AppTester.Checker.Android
+* `Adb:ExecutablePath`: Полный путь к [adb серверу](https://developer.android.com/studio/command-line/adb). Если указан - будет запущен, если еще не был.
 
 ## Вспомогательные сервисы
 Для работы в режиме разработки вспомогательные сервисы наряду с разрабатываемыми представлены в `docker-compose.yml`. При запуске они хранят данные под папкой `dev-data` в корне проекта.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,51 @@ sequenceDiagram
     Controller ->> Moodle: Обновление результата решения
 
 ```
+
+
+## Вспомогательные сервисы
+Для работы в режиме разработки вспомогательные сервисы наряду с разрабатываемыми представлены в `docker-compose.yml`. При запуске они хранят данные под папкой `dev-data` в корне проекта.
+### RabbitMQ
+Если в системе не установлен RabbitMQ, для разработки можно поднять его экземпляр с пользователем `root:root` командой
+```
+docker compose up -d rabbitmq
+```
+После этого сам RabbitMQ будет доступен на порту `5672`, строка подключения будет `amqp://root:root@localhost:5672`
+
+Web интерфейс будет доступен по адресу [http://localhost:15672](http://localhost:15672)
+
+### Сервисы работы с метриками
+Для работы с метриками используются [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), [Prometheus](https://prometheus.io/) и [Grafana](https://grafana.com). Если они не установлены в системе, для разработки мх можно поднять командой
+```
+docker compose up -d otel-collector prometheus grafana
+```
+* OpenTelemetry Collector конфигурация представлена в `otel-collector-config.yaml`, он занимает несколько портов
+    * `4317` для отправки на него метрик по gRPC со стороны сервисов. Строка подключения в конфигурации -  `"OtlpExporterEndpoint": "http://localhost:4317"`
+    * `8888` по пути `/metrics` будут раздаваться метрики самого коллектора
+    * `8889` по пути `/metrics` будут раздаваться метрики сервисов, которые прислали метрики
+* Prometheus конфигурация представлена в `prometheus.yaml`, он занимает порт `9090`
+* Grafana не имеет изначальной конфигурации, занимает порт `3000`
+
+## Метрики
+```mermaid
+sequenceDiagram
+    participant Controller
+    participant Checker.Android
+    participant otel_collector
+    participant Prometheus
+    participant Grafana
+    link otel_collector: Docs @ https://opentelemetry.io/docs/collector/
+    link Prometheus: Docs @ https://prometheus.io/
+    link Grafana: Docs @ https://grafana.com
+    loop отправка метрик
+        Controller ->> otel_collector: gRPC
+        Checker.Android ->> otel_collector: gRPC
+    end
+    Note right of Checker.Android: .NET шлет данные в формате OpenTelemetry
+    loop стягивание метрик
+      Prometheus ->> otel_collector: GET /metrics
+    end
+    loop обновление dashboard
+      Grafana ->> Prometheus: 
+    end
+```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sequenceDiagram
 В рамках разработки параметры можно задавать через [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets)
 ### AppTester.Checker.Android
 * `Adb:ExecutablePath`: Полный путь к [adb серверу](https://developer.android.com/studio/command-line/adb). Если указан - будет запущен, если еще не был.
-
+* `OtlpExporterEndpoint`: Endpoint к Open Telemetry Collector, например `http://localhost:4317`. Если не указан - метрики не будут экспортироваться.
 ## Вспомогательные сервисы
 Для работы в режиме разработки вспомогательные сервисы наряду с разрабатываемыми представлены в `docker-compose.yml`. При запуске они хранят данные под папкой `dev-data` в корне проекта.
 ### RabbitMQ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.9'
+
+services:
+  controller:
+    build:
+      context: .
+      dockerfile: AppsTester.Controller/Dockerfile
+    environment:
+      ConnectionStrings__RabbitMq: amqp://root:root@rabbitmq:5672
+  android-checker:
+    build:
+      context: .
+      dockerfile: AppsTester.Checker.Android/Dockerfile
+    environment:
+      ConnectionStrings__RabbitMq: amqp://root:root@rabbitmq:5672
+  rabbitmq:
+    image: rabbitmq:3.8.26-management-alpine
+    ports:
+      - '5672:5672'
+      - '15672:15672'
+    environment:
+      RABBITMQ_DEFAULT_USER: 'root'
+      RABBITMQ_DEFAULT_PASS: 'root'
+    volumes:
+      - ./dev-data/rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      retries: 3
+  # OpenTelemetry Collector
+  otel-collector:
+    image: otel/opentelemetry-collector:0.67.0
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./dev-data/otel/output:/etc/output # Store the logs
+    ports:
+      - "8888:8888"   # Prometheus metrics exposed by the collector
+      - "8889:8889"   # Prometheus exporter metrics
+      - "4317:4317"   # OTLP gRPC receiver
+  prometheus:
+    image: prom/prometheus:v2.40.6
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: wget -O - http://localhost:9090
+      interval: 10s
+      timeout: 15s
+      retries: 10
+      start_period: 40s
+
+  grafana:
+    image: grafana/grafana-oss:9.3.1
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./dev-data/grafana/storage:/var/lib/grafana

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+# Configure exporters
+exporters:
+  # Export prometheus endpoint
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+  # log to the console
+  logging:
+
+processors:
+  batch:
+
+# Configure pipelines. Pipeline defines a path the data follows in the Collector
+# starting from reception, then further processing or modification and finally
+# exiting the Collector via exporters.
+# https://opentelemetry.io/docs/collector/configuration/#service
+# https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md#pipelines
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, prometheus]

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,0 +1,6 @@
+scrape_configs:
+- job_name: 'otel-collector'
+  scrape_interval: 10s
+  static_configs:
+  - targets: ['otel-collector:8889']
+  - targets: ['otel-collector:8888']


### PR DESCRIPTION
* Добавлены метрики количества подключенных устройств. Используется словарь, так как счетчик +- не подходит, могут пропасть события подключения/отключения, что приводит даже к отрицательным значениям
* В докер обернуты вспомогательные сервисы

open telemetry может раздавать метрики сразу для Prometheus, но делает это как слушатель порта, а прокидывать из Прометея в облаке доступ к android checker-у внутри сети университета(например) - не самая хорошая идея. Потому взят Open Telemetry Collector, который может собирать и метрики, и логи, и трассировки, и он уже потом эти данные может отдавать и Прометею, и зипкину, и кому угодно ещё

Пример получаемой статистики в графане на примере одного телефона
![image](https://user-images.githubusercontent.com/12235437/209097824-4a394ee4-daa6-4fec-bb6e-969cb199d3d5.png)

